### PR TITLE
Fix broken link to ZeroSync repository

### DIFF
--- a/validity_rollups_on_bitcoin.md
+++ b/validity_rollups_on_bitcoin.md
@@ -1187,7 +1187,7 @@ Copyright and related rights to all works produced by third parties referenced i
 
 [^184]: https://github.com/bitcoin-stark/khepri
 
-[^185]: https://github.com/lucidLuckylee/zerosync
+[^185]: https://github.com/zerosync/zerosync
 
 [^186]: https://web.archive.org/web/20201105045447/https://old.reddit.com/r/Bitcoin/comments/izj4a3/technical_confidential_transactions_and_their/
 


### PR DESCRIPTION
The link to the ZeroSync repository changed because the repo was moved to the @ZeroSync organization.